### PR TITLE
fix(streamer): streamer v3 API fixes and improvement

### DIFF
--- a/dotnet/Devolutions.Cadeau.Test/Program.cs
+++ b/dotnet/Devolutions.Cadeau.Test/Program.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Net.WebSockets;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-using Devolutions.Cadeau;
+using System.IO;
+using System.Net.WebSockets;
+using System.Threading;
 
 namespace Devolutions.Cadeau.Test
 {
@@ -403,14 +398,14 @@ namespace Devolutions.Cadeau.Test
 
             streamer.AuthToken = streamAuthToken;
             streamer.TargetHost = streamTargetHost;
-            streamer.streamType = streamType;
+            streamer.StreamType = streamType;
             streamer.FrameWidth = frameWidth;
             streamer.FrameHeight = frameHeight;
             streamer.FrameRate = frameRate;
-            streamer.metadata.Add("ConnectionID", connectionId);
-            streamer.metadata.Add("RepositoryID", repositoryId);
-            streamer.metadata.Add("ConnectionLogID", connectionLogId);
-            streamer.metadata.Add("ConnectionType", "1");
+            streamer.Metadata.Add("ConnectionID", connectionId);
+            streamer.Metadata.Add("RepositoryID", repositoryId);
+            streamer.Metadata.Add("ConnectionLogID", connectionLogId);
+            streamer.Metadata.Add("ConnectionType", "1");
 
             if (!streamer.ConnectUrl(destination))
             {

--- a/dotnet/Devolutions.Cadeau/DucStreamer/BaseDucStreamerBackend.cs
+++ b/dotnet/Devolutions.Cadeau/DucStreamer/BaseDucStreamerBackend.cs
@@ -11,8 +11,6 @@ namespace Devolutions.Cadeau
 
         internal abstract bool KeepAlives { get; }
 
-        protected TimeSpan ConnectTimeout { get; set; }
-
         protected Stream Stream { get; set; }
 
         public bool Connected => this.Stream?.CanWrite ?? false;

--- a/dotnet/Devolutions.Cadeau/DucStreamer/DucStreamerConnector.cs
+++ b/dotnet/Devolutions.Cadeau/DucStreamer/DucStreamerConnector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Devolutions.Cadeau
 {
@@ -96,14 +97,10 @@ namespace Devolutions.Cadeau
             client.Connect(host, port);
 
             NetworkStream clientStream = client.GetStream();
-            RemoteCertificateValidationCallback certificateValidationCallback = null;
+            bool CertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) => 
+                this.OnValidateCertificate?.Invoke(sender, certificate, chain, sslPolicyErrors) ?? false;
 
-            if (this.OnValidateCertificate == null)
-            {
-                certificateValidationCallback = (_, _, _, _) => false;
-            }
-
-            SslStream sslStream = new SslStream(clientStream, false, certificateValidationCallback);
+            SslStream sslStream = new SslStream(clientStream, false, CertificateValidationCallback);
             sslStream.AuthenticateAsClient(host);
             return sslStream;
         }


### PR DESCRIPTION
Fixes and changes for the v3 streamer:

- Restore the `ConnectTimeout` which I neglected to include in the last round of updates (it was never assigned)
- Add support for the certificate validation callback on netstandard2.1 and better consumers
- Properly call the `OnError` handler for failures in `ConnectUrl` (this was never done before)
- Add a `ConnectUrlAsync` function for v3 streamers