### PR TITLE
feat(streamer): add proxy support for v3 streamer

### DIFF
--- a/dotnet/Devolutions.Cadeau/DucStreamer/DucStreamer.cs
+++ b/dotnet/Devolutions.Cadeau/DucStreamer/DucStreamer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -70,6 +71,8 @@ namespace Devolutions.Cadeau
         public OnError OnError { get; set; }
 
         public OnValidateCertificate OnValidateCertificate { get; set; }
+
+        public IWebProxy Proxy { get; set; } = null;
 
         public DucStreamType StreamType
         {
@@ -160,6 +163,7 @@ namespace Devolutions.Cadeau
         {
             DucStreamerV3Backend v3 = new DucStreamerV3Backend();
             v3.ConnectTimeout = ConnectTimeout;
+            v3.Proxy = this.Proxy;
             v3.OnError = this.OnError;
             v3.OnValidateCertificate = this.OnValidateCertificate;
 

--- a/dotnet/Devolutions.Cadeau/DucStreamer/DucStreamerBackendV3.cs
+++ b/dotnet/Devolutions.Cadeau/DucStreamer/DucStreamerBackendV3.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -19,6 +20,8 @@ namespace Devolutions.Cadeau
 
         internal override bool KeepAlives => false;
 
+        internal IWebProxy Proxy { get; set; } = null;
+
         internal OnValidateCertificate OnValidateCertificate { get; set; }
 
         public override bool IsRawData => true;
@@ -33,6 +36,11 @@ namespace Devolutions.Cadeau
                 this.OnValidateCertificate?.Invoke(sender, certificate, chain, sslPolicyErrors) ?? false;
             webSocket.Options.RemoteCertificateValidationCallback = CertificateValidationCallback;
 #endif
+
+            if (this.Proxy != null)
+            {
+                webSocket.Options.Proxy = this.Proxy;
+            }
 
             using CancellationTokenSource timeout = new CancellationTokenSource(this.ConnectTimeout);
             using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);


### PR DESCRIPTION
Add web proxy support for the v3 streamer. This is a quality-of-life improvement to observe traffic in the streamer using a web proxy.