### PR TITLE
fix(ffi): XmfRecorder and XmfBipBuffer safehandle, thread safety and dispose semantics

### DIFF
--- a/dotnet/Devolutions.Cadeau/XmfMkvStream.cs
+++ b/dotnet/Devolutions.Cadeau/XmfMkvStream.cs
@@ -6,14 +6,32 @@ namespace Devolutions.Cadeau
     public class XmfMkvStream : Stream
     {
         public override bool CanRead => true;
+
         public override bool CanWrite => false;
+
         public override bool CanSeek => false;
 
-        public XmfBipBuffer bb;
+        [Obsolete("Use BipBuffer property instead")]
+        public XmfBipBuffer bb => this.BipBuffer;
+
+        private XmfBipBuffer bipBuffer = new();
+
+        public XmfBipBuffer BipBuffer
+        {
+            get => this.bipBuffer;
+            private set => this.bipBuffer = value;
+        }
 
         public XmfMkvStream()
         {
-            bb = new XmfBipBuffer();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.BipBuffer?.Dispose();
+            this.BipBuffer = null;
+
+            base.Dispose(disposing);
         }
 
         public override long Length
@@ -51,8 +69,8 @@ namespace Devolutions.Cadeau
         {
             unsafe {
                 fixed (byte* ptr = buffer) {
-                    IntPtr data = new IntPtr(&ptr[offset]);
-                    return bb.Read(data, (nuint) count);
+                    IntPtr data = new(&ptr[offset]);
+                    return this.BipBuffer.Read(data, (nuint) count);
                 }
             }
         }


### PR DESCRIPTION
At the core of the issue, `XmfRecorder` is used by RDM from multiple threads. If we have a case where recording is stopped (and `XmfRecorder.Uninit` is called) while a frame is still being encoded on another thread we have a hard crash.

`XmfRecorder` now uses a lock around all function calls at the FFI boundary. Further safety improvements are provided by using a handle derived from `SafeHandle` instead of raw `IntPtr`. We also now have proper `Dispose` semantics instead of relying on the finalizer for cleanup.

If used properly the `XmfBipBuffer` and `XmfMkvStream` shouldn't have the same thread-safety issues; however I've noticed that we don't have `Dispose` semantics here either. This is more of a concern since the bip buffer creates a default allocation of 16MB (which can easily grow), but cleanup is left to the finalizer. This means that it's non-deterministic and will always persist until the second generation GC. With enough of these buffers in use that can impact GC performance. Cleanup may also not happen at all In certain cases, such as a thread abort.

So, we convert to `SafeHandle` here as well to get better integration with the GC and deterministic disposal.

Additionally some small API improvements (for example, `Obsolete`ing public fields and replacing them with properties).